### PR TITLE
トップページの列数可変対応と動画プレイヤーのWeb操作修正

### DIFF
--- a/lib/pages/animal_page.dart
+++ b/lib/pages/animal_page.dart
@@ -242,6 +242,39 @@ class _AnimalPageState extends State<AnimalPage> {
     }
   }
 
+  /// 再生・停止ボタンの表示を切り替える。表示してから2.5秒で自動的に隠す。
+  void _toggleControls() {
+    _timer?.cancel();
+    setState(() {
+      _onTouch = !_onTouch;
+    });
+    _timer = Timer.periodic(const Duration(milliseconds: 2500), (_) {
+      setState(() {
+        _onTouch = false;
+      });
+    });
+  }
+
+  /// 動画の再生と停止を切り替える。
+  void _togglePlayPause() {
+    _timer?.cancel();
+    setState(() {
+      if (_videoController.value.isPlaying) {
+        _videoController.pause();
+        isStop = true;
+      } else {
+        _videoController.play();
+        isStop = false;
+      }
+    });
+    // 2.5秒したらボタン消える
+    _timer = Timer.periodic(const Duration(milliseconds: 2500), (_) {
+      setState(() {
+        _onTouch = false;
+      });
+    });
+  }
+
   @override
   void dispose() {
     _videoController.dispose();
@@ -277,116 +310,63 @@ class _AnimalPageState extends State<AnimalPage> {
               constraints: const BoxConstraints(maxWidth: 840),
               child: Column(
                 children: [
-                  GestureDetector(
-                    onTap: () {
-                      _timer?.cancel();
-                      setState(() {
-                        _onTouch = !_onTouch;
-                      });
-                      //3秒したらボタン消える
-                      _timer = Timer.periodic(
-                          const Duration(milliseconds: 2500), (_) {
-                        setState(() {
-                          _onTouch = false;
-                        });
-                      });
-                    },
+                  // 動画は画面幅にそのまま追従させず、最大幅を決めて中央に置く。
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 640),
                     child: AspectRatio(
                       aspectRatio: 16 / 9.5,
                       child: _videoController.value.isInitialized
                           //動画再生部分
-                          ? Stack(alignment: Alignment.bottomCenter, children: [
-                              VideoPlayer(_videoController),
-                              for (var index = 0;
-                                  index <
-                                      widget.selectedAnimal.onomatopoeiaList
-                                          .length;
-                                  index++)
-                                Align(
-                                  alignment: Alignment(
-                                    offsetList[index].dx,
-                                    offsetList[index].dy,
+                          ? Stack(
+                              alignment: Alignment.bottomCenter,
+                              children: [
+                                VideoPlayer(_videoController),
+                                // 流れる鳴き声コメント。
+                                // ClipRect はプラットフォームビュー(video)上の
+                                // オーバーレイ描画に効かないことがあるため、
+                                // CustomPaint 内でキャンバスをクリップして
+                                // 動画の外へはみ出さないように描画する。
+                                Positioned.fill(
+                                  child: CustomPaint(
+                                    painter: _FlowingOnomatopoeiaPainter(
+                                      comments: widget
+                                          .selectedAnimal.onomatopoeiaList,
+                                      offsets: offsetList,
+                                    ),
                                   ),
-                                  child: SizedBox(
-                                    width: 32,
-                                    height: 1,
-                                    child: OverflowBox(
-                                      minWidth: 100,
-                                      maxWidth: 400,
-                                      minHeight: 80,
-                                      maxHeight: 80,
-                                      child: Stack(
-                                        children: [
-                                          Text(
-                                            widget.selectedAnimal
-                                                .onomatopoeiaList[index],
-                                            style: TextStyle(
-                                              fontSize: 24,
-                                              fontWeight: FontWeight.bold,
-                                              foreground: Paint()
-                                                ..style = PaintingStyle.stroke
-                                                ..strokeWidth = 1
-                                                ..color = Colors.black,
-                                            ),
-                                          ),
-                                          Text(
-                                            widget.selectedAnimal
-                                                .onomatopoeiaList[index],
-                                            style: const TextStyle(
-                                              fontSize: 24,
-                                              color: Colors.white,
-                                              fontWeight: FontWeight.bold,
-                                            ),
-                                          ),
-                                        ],
+                                ),
+                                // タップで再生・停止ボタンの表示を切り替える。
+                                // Web では video 要素がタップを吸わないよう
+                                // index.html 側で pointer-events を無効化している。
+                                Positioned.fill(
+                                  child: GestureDetector(
+                                    behavior: HitTestBehavior.opaque,
+                                    onTap: _toggleControls,
+                                  ),
+                                ),
+                                Visibility(
+                                  visible: _onTouch,
+                                  child: Center(
+                                    child: MaterialButton(
+                                      padding: const EdgeInsets.all(15), //パディング
+                                      color: Colors.black38, //背景色
+                                      textColor: Colors.white, //アイコンの色
+                                      shape: const CircleBorder(), //丸
+                                      onPressed: _togglePlayPause,
+                                      child: Icon(
+                                        _videoController.value.isPlaying
+                                            ? Icons.pause
+                                            : Icons.play_arrow,
+                                        color: Colors.white,
+                                        size: 35,
                                       ),
                                     ),
                                   ),
                                 ),
-                              Visibility(
-                                visible: _onTouch,
-                                child: Center(
-                                  child: MaterialButton(
-                                    padding: const EdgeInsets.all(15), //パディング
-                                    color: Colors.black38, //背景色
-                                    textColor: Colors.white, //アイコンの色
-                                    shape: const CircleBorder(), //丸
-                                    onPressed: () {
-                                      _timer?.cancel();
-
-                                      // 再生、停止切り替え
-                                      setState(() {
-                                        if (_videoController.value.isPlaying) {
-                                          _videoController.pause();
-                                          isStop = true;
-                                        } else {
-                                          _videoController.play();
-                                          isStop = false;
-                                        }
-                                      });
-
-                                      // 3秒したらボタン消える
-                                      _timer = Timer.periodic(
-                                          const Duration(milliseconds: 2500),
-                                          (_) {
-                                        setState(() {
-                                          _onTouch = false;
-                                        });
-                                      });
-                                    },
-                                    child: Icon(
-                                      _videoController.value.isPlaying
-                                          ? Icons.pause
-                                          : Icons.play_arrow,
-                                      color: Colors.white,
-                                      size: 35,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              VideoProgressIndicator(_videoController,
-                                  allowScrubbing: true),
-                            ])
+                                VideoProgressIndicator(_videoController,
+                                    allowScrubbing: true),
+                              ],
+                            )
                           : const Center(child: CircularProgressIndicator()),
                     ),
                   ),
@@ -656,4 +636,70 @@ class _AnimalSoundTile extends StatelessWidget {
       ),
     );
   }
+}
+
+/// 動画の上を流れる鳴き声コメントを描画する。
+///
+/// ClipRect はプラットフォームビュー(video)上のオーバーレイ描画に
+/// 効かないことがあるため、キャンバス自体をクリップして
+/// コメントが動画の外へはみ出さないようにする。
+class _FlowingOnomatopoeiaPainter extends CustomPainter {
+  _FlowingOnomatopoeiaPainter({
+    required this.comments,
+    required this.offsets,
+  });
+
+  final List<String> comments;
+  final List<Offset> offsets;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.clipRect(Offset.zero & size);
+    final count = min(comments.length, offsets.length);
+    for (var index = 0; index < count; index++) {
+      final alignment = offsets[index];
+
+      final fillPainter = TextPainter(
+        text: TextSpan(
+          text: comments[index],
+          style: const TextStyle(
+            fontSize: 24,
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout(maxWidth: 400);
+      final strokePainter = TextPainter(
+        text: TextSpan(
+          text: comments[index],
+          style: TextStyle(
+            fontSize: 24,
+            fontWeight: FontWeight.bold,
+            foreground: Paint()
+              ..style = PaintingStyle.stroke
+              ..strokeWidth = 1
+              ..color = Colors.black,
+          ),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout(maxWidth: 400);
+
+      // 以前の Align + OverflowBox と同じ位置になるように座標を計算する。
+      final anchor = Offset(
+        (size.width - 32) * (alignment.dx + 1) / 2,
+        (size.height - 1) * (alignment.dy + 1) / 2,
+      );
+      final boxWidth = max(100.0, fillPainter.width);
+      final topLeft = Offset(
+        anchor.dx + 16 - boxWidth / 2,
+        anchor.dy + 0.5 - 40,
+      );
+      strokePainter.paint(canvas, topLeft);
+      fillPainter.paint(canvas, topLeft);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _FlowingOnomatopoeiaPainter oldDelegate) => true;
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -113,14 +113,17 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _initializeNotification() async {
     const initializationSettingsIOS = DarwinInitializationSettings();
-    const initializationSettingsAndroid = AndroidInitializationSettings('ic_notification');
+    const initializationSettingsAndroid =
+        AndroidInitializationSettings('ic_notification');
 
-    const InitializationSettings initializationSettings = InitializationSettings(
+    const InitializationSettings initializationSettings =
+        InitializationSettings(
       android: initializationSettingsAndroid,
       iOS: initializationSettingsIOS,
     );
     final enable = await _flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
         ?.requestNotificationsPermission();
     if (enable == false) {
       return;
@@ -129,7 +132,8 @@ class _HomePageState extends State<HomePage> {
       settings: initializationSettings,
       onDidReceiveNotificationResponse: (response) {
         print(response.payload);
-        final animal = animals.firstWhereOrNull((element) => element.name == response.payload);
+        final animal = animals
+            .firstWhereOrNull((element) => element.name == response.payload);
         if (animal == null) {
           return;
         }
@@ -202,7 +206,8 @@ class _HomePageState extends State<HomePage> {
                         TextButton(
                           onPressed: () => Navigator.of(context).push(
                             MaterialPageRoute(
-                              builder: (context) => const WhatIsOnomatopoeiaPage(),
+                              builder: (context) =>
+                                  const WhatIsOnomatopoeiaPage(),
                             ),
                           ),
                           child: const Text(
@@ -224,8 +229,11 @@ class _HomePageState extends State<HomePage> {
                             physics: const NeverScrollableScrollPhysics(),
                             shrinkWrap: true,
                             itemCount: animals.length,
-                            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                              crossAxisCount: 2,
+                            // 1タイルの最大幅を決めておき、画面が広くなるほど
+                            // 2列→3列→4列…と列数が自動で増えるようにする。
+                            gridDelegate:
+                                const SliverGridDelegateWithMaxCrossAxisExtent(
+                              maxCrossAxisExtent: 200,
                               childAspectRatio: 1,
                               mainAxisSpacing: 16,
                               crossAxisSpacing: 16,
@@ -238,7 +246,8 @@ class _HomePageState extends State<HomePage> {
                                 onTap: animal.onomatopoeiaVideoUrl.isNotEmpty
                                     ? () => Navigator.of(context).push(
                                           MaterialPageRoute(
-                                            builder: (context) => AnimalPage(selectedAnimal: animal),
+                                            builder: (context) => AnimalPage(
+                                                selectedAnimal: animal),
                                           ),
                                         )
                                     : null,

--- a/lib/pages/sound_page.dart
+++ b/lib/pages/sound_page.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:mcr/models/animal_sound.dart';
@@ -58,6 +59,35 @@ class _SoundPageState extends State<SoundPage> {
     initializeVideoPlayer();
   }
 
+  /// 再生・停止ボタンの表示を切り替える。表示してから2.5秒で自動的に隠す。
+  void _toggleControls() {
+    _timer?.cancel();
+    setState(() {
+      _onTouch = !_onTouch;
+    });
+    _timer = Timer.periodic(const Duration(milliseconds: 2500), (_) {
+      setState(() {
+        _onTouch = false;
+      });
+    });
+  }
+
+  /// 動画の再生と停止を切り替える。
+  void _togglePlayPause() {
+    _timer?.cancel();
+    setState(() {
+      _videoController!.value.isPlaying
+          ? _videoController?.pause()
+          : _videoController?.play();
+    });
+    // 2.5秒したらボタン消える
+    _timer = Timer.periodic(const Duration(milliseconds: 2500), (_) {
+      setState(() {
+        _onTouch = false;
+      });
+    });
+  }
+
   @override
   void dispose() {
     super.dispose();
@@ -68,6 +98,8 @@ class _SoundPageState extends State<SoundPage> {
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
+    // 動画は画面幅にそのまま追従させず、最大幅を決めて中央に置く。
+    final videoSize = min(screenWidth, 640.0);
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: PreferredSize(
@@ -92,29 +124,27 @@ class _SoundPageState extends State<SoundPage> {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               if (widget.selectedAnimalSound.videoUrl.isNotEmpty)
-                GestureDetector(
-                  onTap: () {
-                    _timer?.cancel();
-                    setState(() {
-                      _onTouch = !_onTouch;
-                    });
-                    //3秒したらボタン消える
-                    _timer = Timer.periodic(const Duration(milliseconds: 2500), (_) {
-                      setState(() {
-                        _onTouch = false;
-                      });
-                    });
-                  },
+                Center(
                   child: SizedBox(
-                      height: screenWidth,
+                      width: videoSize,
+                      height: videoSize,
                       child: _videoController?.value.isInitialized == true
                           ? Stack(
                               alignment: Alignment.bottomCenter,
                               children: [
                                 VideoPlayer(_videoController!),
+                                // タップで再生・停止ボタンの表示を切り替える。
+                                // Web では video 要素がタップを吸わないよう
+                                // index.html 側で pointer-events を無効化している。
+                                Positioned.fill(
+                                  child: GestureDetector(
+                                    behavior: HitTestBehavior.opaque,
+                                    onTap: _toggleControls,
+                                  ),
+                                ),
                                 Visibility(
                                   visible: _onTouch,
                                   child: Center(
@@ -123,32 +153,19 @@ class _SoundPageState extends State<SoundPage> {
                                       color: Colors.black38, //背景色
                                       textColor: Colors.white, //アイコンの色
                                       shape: const CircleBorder(), //丸
-                                      onPressed: () {
-                                        _timer?.cancel();
-
-                                        // 再生、停止切り替え
-                                        setState(() {
-                                          _videoController!.value.isPlaying
-                                              ? _videoController?.pause()
-                                              : _videoController?.play();
-                                        });
-
-                                        // 3秒したらボタン消える
-                                        _timer = Timer.periodic(const Duration(milliseconds: 2500), (_) {
-                                          setState(() {
-                                            _onTouch = false;
-                                          });
-                                        });
-                                      },
+                                      onPressed: _togglePlayPause,
                                       child: Icon(
-                                        _videoController!.value.isPlaying ? Icons.pause : Icons.play_arrow,
+                                        _videoController!.value.isPlaying
+                                            ? Icons.pause
+                                            : Icons.play_arrow,
                                         color: Colors.white,
                                         size: 35,
                                       ),
                                     ),
                                   ),
                                 ),
-                                VideoProgressIndicator(_videoController!, allowScrubbing: true),
+                                VideoProgressIndicator(_videoController!,
+                                    allowScrubbing: true),
                               ],
                             )
                           : const Center(

--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,18 @@
 
   <title>mcr</title>
   <link rel="manifest" href="manifest.json">
+
+  <style>
+    /*
+      video_player / Image.network が生成する <video> <img> 要素が
+      タップやクリックを吸ってしまい Flutter 側の GestureDetector に
+      届かなくなるため、ポインターイベントを素通しさせる。
+    */
+    flt-platform-view video,
+    flt-platform-view img {
+      pointer-events: none;
+    }
+  </style>
 </head>
 <body>
   <!--


### PR DESCRIPTION
- トップページのグリッドを2列固定から画面幅に応じて列数が増える方式に変更
- 動物詳細・鳴き声ページの動画に最大幅640pxを設定し中央寄せ
- Webで<video>要素がタップを吸ってFlutterに届かない問題をindex.htmlのpointer-events:noneで解消し、再生・停止操作を可能にした
- 流れる鳴き声コメントはClipRectがプラットフォームビュー上で効かないため、CustomPaintのキャンバスクリップ描画に変更して動画外へのはみ出しを解消